### PR TITLE
refactor(masstransit): update to masstransit 8

### DIFF
--- a/MassTransit/Hypothesist.MassTransit/Hypothesist.MassTransit.csproj
+++ b/MassTransit/Hypothesist.MassTransit/Hypothesist.MassTransit.csproj
@@ -7,7 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="MassTransit" Version="[7,)" />
+      <PackageReference Include="MassTransit" Version="[8,)" />
     </ItemGroup>
 
     <ItemGroup>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -34,7 +34,7 @@ for:
         secure: zNvmKO5DpbfDRV+WFnyaetwbAexTXGi4rMSwJH9NnTtOS3SDAUjD8CIVGRsReMRf
     after_test:
       - bash <(curl -s https://codecov.io/bash)
-      - dotnet tool restore && cd Hypothesist.Tests && dotnet dotnet-stryker --reporter dashboard --dashboard-api-key $STRYKER_DASHBOARD_API_KEY -c 4
+      - dotnet tool restore && cd Hypothesist.Tests && dotnet dotnet-stryker --reporter dashboard --dashboard-api-key $STRYKER_DASHBOARD_API_KEY --concurrency 4
     deploy:
       - provider: NuGet
         api_key:


### PR DESCRIPTION
MassTransit 8 has been out for a while now. Between 7 and 8, Chris moved around some classes so we're running into compatibility issues. This PR sets the MT baseline to `8.*`