### PR TITLE
feat(netstandard): multi-target netstandard2.0 and netstandard2.1

### DIFF
--- a/Hypothesist/ChannelReaderExtensions.cs
+++ b/Hypothesist/ChannelReaderExtensions.cs
@@ -1,0 +1,29 @@
+﻿#if !NETSTANDARD2_1_OR_GREATER
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Channels;
+
+namespace Hypothesist;
+
+internal static class ChannelReaderExtensions
+{
+    /// <summary>Creates an <see cref="IAsyncEnumerable{T}"/> that enables reading all of the data from the channel.</summary>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to use to cancel the enumeration.</param>
+    /// <remarks>
+    /// Each <see cref="IAsyncEnumerator{T}.MoveNextAsync"/> call that returns <c>true</c> will read the next item out of the channel.
+    /// <see cref="IAsyncEnumerator{T}.MoveNextAsync"/> will return false once no more data is or will ever be available to read.
+    /// </remarks>
+    /// <returns>The created async enumerable.</returns>
+    public static async IAsyncEnumerable<T> ReadAllAsync<T>(this ChannelReader<T> reader, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        while (await reader.WaitToReadAsync(cancellationToken).ConfigureAwait(false))
+        {
+            while (reader.TryRead(out T item))
+            {
+                yield return item;
+            }
+        }
+    }
+}
+#endif

--- a/Hypothesist/Experiments/All.cs
+++ b/Hypothesist/Experiments/All.cs
@@ -25,5 +25,10 @@ internal sealed class All<T> : IExperiment<T>
         _matched.Add(value);
     }
 
+    #if NETSTANDARD2_0
+    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+    void IObserver<T>.OnError(Exception error) => throw new NotImplementedException();
+    #endif
+
     bool IExperiment<T>.Done => false;
 }

--- a/Hypothesist/Experiments/AtLeast.cs
+++ b/Hypothesist/Experiments/AtLeast.cs
@@ -28,5 +28,10 @@ internal class AtLeast<T> : IExperiment<T>
         Done = _matched.Count >= _occurrences;
     }
 
+    #if NETSTANDARD2_0
+    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+    void IObserver<T>.OnError(Exception error) => throw new NotImplementedException();
+    #endif
+
     public bool Done { get; private set; }
 }

--- a/Hypothesist/Experiments/Exactly.cs
+++ b/Hypothesist/Experiments/Exactly.cs
@@ -26,5 +26,10 @@ public class Exactly<T> : IExperiment<T>
     void IObserver<T>.OnNext(T value) => 
         (_match(value) ? _matched : _unmatched).Add(value);
 
+    #if NETSTANDARD2_0
+    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+    void IObserver<T>.OnError(Exception error) => throw new NotImplementedException();
+    #endif
+
     bool IExperiment<T>.Done => false;
 }

--- a/Hypothesist/Experiments/First.cs
+++ b/Hypothesist/Experiments/First.cs
@@ -23,5 +23,10 @@ public class First<T> : IExperiment<T>
         Done = true;
     }
 
+    #if NETSTANDARD2_0
+    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+    void IObserver<T>.OnError(Exception error) => throw new NotImplementedException();
+    #endif
+
     public bool Done { get; private set; }
 }

--- a/Hypothesist/Experiments/IExperiment.cs
+++ b/Hypothesist/Experiments/IExperiment.cs
@@ -5,8 +5,10 @@ namespace Hypothesist.Experiments;
 
 public interface IExperiment<in T> : IObserver<T>
 {
+    #if NETSTANDARD2_1_OR_GREATER
     [ExcludeFromCodeCoverage]
     void IObserver<T>.OnError(Exception error) => throw new NotImplementedException();
-    
+    #endif
+
     bool Done { get; }
 }

--- a/Hypothesist/Hypothesist.csproj
+++ b/Hypothesist/Hypothesist.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
         <LangVersion>latest</LangVersion>
     </PropertyGroup>
 
@@ -23,4 +23,10 @@
         <None Include="..\README.md" Pack="true" PackagePath="" />
         <None Include="..\docs\img\hypothesize.svg" Pack="true" PackagePath="docs\img" />
     </ItemGroup>
+
+    <ItemGroup>
+      <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="7.0.0" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
+      <PackageReference Include="System.Threading.Channels" Version="6.0.0" />
+    </ItemGroup>
+
 </Project>

--- a/MassTransit/Hypothesist.MassTransit/Hypothesist.MassTransit.csproj
+++ b/MassTransit/Hypothesist.MassTransit/Hypothesist.MassTransit.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>netstandard2.0</TargetFramework>
         <RootNamespace>Hypothesist</RootNamespace>
         <LangVersion>Latest</LangVersion>
     </PropertyGroup>

--- a/Rebus/Hypothesist.Rebus/Hypothesist.Rebus.csproj
+++ b/Rebus/Hypothesist.Rebus/Hypothesist.Rebus.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>netstandard2.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <LangVersion>latest</LangVersion>

--- a/ServiceBus/Hypothesist.ServiceBus/Hypothesist.ServiceBus.csproj
+++ b/ServiceBus/Hypothesist.ServiceBus/Hypothesist.ServiceBus.csproj
@@ -1,9 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>netstandard2.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
+        <LangVersion>latest</LangVersion>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
I currently have a need (or at least the strong desire) to use Hypothesist in the unit tests of some legacy projects that must target .NET Framework, however it's not possible while Hypothesist only targets .NET Core 3.1.  It'll make a whole bunch of my tests so much simpler and faster.

To support my scenario, this PR changes the targeted frameworks to .NET Standard 2.0 and 2.1.

On netstandard2.0 I had to polyfill ChannelReader<T>.ReadAllAsync and also use preprocessor directives to work around the lack of support for default interface methods.

Ony my own PC I also added a net4.8 framework target to the Hypothesist.Tests project but have not committed it as I'm unfamiliar with your CI system and do not know whether it's able to use that runtime.

If you'd like anything in this PR done differently, I'm keen to make the appropriate changes!